### PR TITLE
hook up electrumProxy setting for using socks5 proxy with Tor or Mesh

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ android {
             resValue "string", "app_name", "BD Wallet | REGTEST"
             resValue "string", "app_network", "regtest"
             resValue "string", "app_electrum_url", "tcp://127.0.0.1:60401"
+            resValue "string", "app_electrum_proxy", ""
             isDefault true
         }
 
@@ -62,6 +63,17 @@ android {
             resValue "string", "app_name", "BD Wallet | TESTNET"
             resValue "string", "app_network", "testnet"
             resValue "string", "app_electrum_url", "tcp://testnet.aranguren.org:51001"
+            resValue "string", "app_electrum_proxy", ""
+        }
+
+        tor {
+            dimension 'appNetwork'
+            applicationIdSuffix ".tor"
+            versionNameSuffix "-tor"
+            resValue "string", "app_name", "BD Wallet | TOR"
+            resValue "string", "app_network", "testnet"
+            resValue "string", "app_electrum_url", "tcp://testnet.aranguren.org:51001"
+            resValue "string", "app_electrum_proxy", "socks5://127.0.0.1:9050"
         }
     }
 

--- a/app/src/main/java/org/bdwallet/app/BDWApplication.kt
+++ b/app/src/main/java/org/bdwallet/app/BDWApplication.kt
@@ -33,6 +33,7 @@ class BDWApplication : Application() {
     private lateinit var descriptor: String
     private lateinit var changeDescriptor: String
     private lateinit var electrumUrl: String
+    private var electrumProxy: String? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -52,6 +53,7 @@ class BDWApplication : Application() {
         this.network = getString(R.string.app_network)
         this.path = applicationContext.filesDir.toString()
         this.electrumUrl = getString(R.string.app_electrum_url)
+        this.electrumProxy = getString(R.string.app_electrum_proxy).ifEmpty { null }
     }
 
     // Get mapping from String to Network enum
@@ -80,6 +82,7 @@ class BDWApplication : Application() {
         this.descriptor = descriptor
         this.changeDescriptor = change_descriptor
         this.electrumUrl = electrum_url
+        this.electrumProxy = electrum_proxy
 
         walletPtr = lib.constructor(
             WalletConstructor(
@@ -106,7 +109,7 @@ class BDWApplication : Application() {
             descriptor,
             changeDescriptor,
             electrumUrl,
-            null
+            electrumProxy
         )
         saveWalletPrefs()
     }
@@ -121,6 +124,7 @@ class BDWApplication : Application() {
         editor.putString("descriptor", descriptor)
         editor.putString("changeDescriptor", changeDescriptor)
         editor.putString("electrum_url", electrumUrl)
+        editor.putString("electrum_proxy", electrumProxy)
         editor.commit()
     }
 

--- a/app/src/main/java/org/bdwallet/app/EntryActivity.kt
+++ b/app/src/main/java/org/bdwallet/app/EntryActivity.kt
@@ -23,6 +23,7 @@ class EntryActivity : AppCompatActivity() {
             val descriptor: String = savedWallet.getString("descriptor", null)!!
             val changeDescriptor: String = savedWallet.getString("changeDescriptor", null)!!
             val electrumUrl: String = savedWallet.getString("electrum_url", null)!!
+            val electrumProxy: String? = savedWallet.getString("electrum_proxy", null)
             val app = application as BDWApplication
             app.initialize(
                 name,
@@ -31,7 +32,7 @@ class EntryActivity : AppCompatActivity() {
                 descriptor,
                 changeDescriptor,
                 electrumUrl,
-                null
+                electrumProxy
             )
         }
         startActivity(Intent(this, Class.forName(getNextActivityName(isWalletInitialized))))


### PR DESCRIPTION
Replacement PR for #21 after removing large blogs from `master` branch.

"This adds a new build variant for testing with a Tor proxy.

I've tested using a socks5 proxy that uses Mesh radios as well as Orbot and Tor Browser on my PC as the proxy.

TODO: add proxy to settings dialog and reconnect to electrum when proxy changes."
