### PR TITLE
fix amount parsing and btcusd fetching from withdraw fragment

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="toast_invalid_seed_phrase">Invalid seed phrase</string>
     <string name="toast_invalid_address">Invalid recipient address</string>
     <string name="toast_insufficient_balance">Insufficient wallet balance</string>
+    <string name="toast_invalid_amount">Invalid amount value</string>
     <string name="payment_dialog_title">Payment Review</string>
     <string name="payment_dialog_recipient">Recipient:</string>
     <string name="payment_dialog_amount">Amount:</string>


### PR DESCRIPTION
Replacement PR for #19 after removing large blogs from master branch.

"The 'Withdraw' functionality was failing at the 'review' step because the sats withdraw amount was being passed as a decimal number.
Eg. "10000.000" should have been sent as "10000"

Was also crashing because price data was not sync'd before 'review' step. I added that price sync in a background thread when fragment is created."

