### PR TITLE
Update `bdk-jni` version to `0.2.0` which provides `bdk` version 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /captures
 .externalNativeBuild
 .cxx
+*.aar

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 
+### Install bdk-jni
+
+1a. Clone [`bdk-jni` project](https://github.com/bitcoindevkit/bdk-jni)
+
+2a. Follow README instruction to publish .aar files to local maven repository
+
+OR
+
+1b. Copy `bdk-jni-debug-0.2.0.aar` to `app/libs` folder in BDWallet project 
+
 ### Build
-
-1. Clone [`bdk-jni` project](https://github.com/bitcoindevkit/bdk-jni)
-
-1. Follow README instruction to publish .aar files to local maven repository
 
 1. Build with gradle
 
@@ -36,30 +42,29 @@
     rtcli getnewaddress  
     rtstop
     ```
+   
+1. Use "AVD Manager" to lauch a virtual device (eg. "Pixel 3a API 30" or similar)  
 
-4. Configure Android Studio ADB
-
-   "Use existing manually managed server" on port 5038
-
-5. From localhost command line stop and restart adb with port forwarding
+1. From localhost command line setup adb with port forwarding, use same adb version as Android Studio
 
    ```shell
-   adb -P 5037 kill-server
-   adb -P 5038 devices -l
-   adb -L tcp:localhost:5038 reverse tcp:60401 tcp:60401
-   adb -L tcp:localhost:5038 reverse --list
+   ~/Android/Sdk/platform-tools/adb devices -l
+   ~/Android/Sdk/platform-tools/adb -L tcp:localhost:5037 reverse tcp:60401 tcp:60401
+   ~/Android/Sdk/platform-tools/adb -L tcp:localhost:5037 reverse --list
    ```
 
-6. Open Android Studio "Build Variants" window (lower left)
+1. Open Android Studio "Build Variants" window (lower left)
 
-7. Select Active Build Variant "localDebug"
+1. Select Active Build Variant "localDebug"
 
-8. Run or Debug "app"
+1. Run or Debug "app"
 
-9. Create a new wallet
+1. Create a new wallet and create a deposit address
 
-10. Send testnet coins to emulated wallet
+1. Send regtest coins to emulated wallet, and generate a block
 
    ```shell
-   rtcli sendtoaddress bcrt1qfs7ug9d9xa8hrj8tdtxqsrylgw3fvw637xrepu 2.345
+   rtcli sendtoaddress <deposit address> 2.345
+   rtcli getnewaddress
+   rtcli generatetoaddress 1 <newaddress>
    ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 
-How to test with local REGTEST electrs server
+### Build
+
+1. Clone [`bdk-jni` project](https://github.com/bitcoindevkit/bdk-jni)
+
+1. Follow README instruction to publish .aar files to local maven repository
+
+1. Build with gradle
+
+   ```
+   ./gradlew build
+   ```
+
+### Test
+
+#### With local REGTEST electrs server
 
 1. Install [docker desktop](https://www.docker.com/get-started)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation fileTree(dir: 'libs', include: ['*.aar'])
     implementation 'io.reactivex.rxjava3:rxjava:3.0.3'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.2'
@@ -115,7 +114,6 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.7.2' //retrofit
     implementation 'com.squareup.picasso:picasso:2.71828'
     annotationProcessor 'androidx.room:room-compiler:2.2.5'
-
-
-    implementation "org.bitcoindevkit.bdkjni:bdk-jni:0.1.0-beta.1@aar"
+    
+    implementation "org.bitcoindevkit.bdkjni:bdk-jni-debug:0.2.0@aar"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,9 +101,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    
     implementation "org.jetbrains.anko:anko-commons:0.10.4"
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.10"

--- a/app/src/main/java/org/bdwallet/app/BDWApplication.kt
+++ b/app/src/main/java/org/bdwallet/app/BDWApplication.kt
@@ -185,21 +185,21 @@ class BDWApplication : Application() {
     }
 
     // Generate a new mnemonic and tpriv (for creating wallet)
-    fun generateExtendedKey(mnemonicWordCount: Int): ExtendedKeys {
-        return lib.generate_extended_key(getNetworkMap().getValue(network), mnemonicWordCount)
+    fun generateExtendedKey(mnemonicWordCount: Int, password: String?): ExtendedKey {
+        return lib.generate_extended_key(getNetworkMap().getValue(network), mnemonicWordCount, password)
     }
 
     // Use a mnemonic to calculate the tpriv (for recovering wallet)
-    fun createExtendedKeys(mnemonic: String): ExtendedKeys {
-        return lib.create_extended_keys(getNetworkMap().getValue(network), mnemonic)
+    fun restoreExtendedKey(mnemonic: String, password: String?): ExtendedKey {
+        return lib.restore_extended_key(getNetworkMap().getValue(network), mnemonic, password)
     }
 
     // Concatenate tpriv to create descriptor
-    fun createDescriptor(keys: ExtendedKeys): String {
-        return ("wpkh(" + keys.ext_priv_key + "/0/*)")
+    fun createDescriptor(keys: ExtendedKey): String {
+        return ("wpkh(" + keys.xprv + "/0/*)")
     }
 
-    fun createChangeDescriptor(keys: ExtendedKeys): String {
-        return ("wpkh(" + keys.ext_priv_key + "/1/*)")
+    fun createChangeDescriptor(keys: ExtendedKey): String {
+        return ("wpkh(" + keys.xprv + "/1/*)")
     }
 }

--- a/app/src/main/java/org/bdwallet/app/BDWApplication.kt
+++ b/app/src/main/java/org/bdwallet/app/BDWApplication.kt
@@ -19,7 +19,6 @@ package org.bdwallet.app
 import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import org.bitcoindevkit.bdkjni.Lib
 import org.bitcoindevkit.bdkjni.Types.*
 
@@ -195,11 +194,11 @@ class BDWApplication : Application() {
     }
 
     // Concatenate tpriv to create descriptor
-    fun createDescriptor(keys: ExtendedKey): String {
-        return ("wpkh(" + keys.xprv + "/0/*)")
+    fun createDescriptor(key: ExtendedKey): String {
+        return ("wpkh(" + key.xprv + "/0/*)")
     }
-
-    fun createChangeDescriptor(keys: ExtendedKey): String {
-        return ("wpkh(" + keys.xprv + "/1/*)")
+    
+    fun createChangeDescriptor(key: ExtendedKey): String {
+        return ("wpkh(" + key.xprv + "/1/*)")
     }
 }

--- a/app/src/main/java/org/bdwallet/app/ui/init/CreateWalletSeedActivity.kt
+++ b/app/src/main/java/org/bdwallet/app/ui/init/CreateWalletSeedActivity.kt
@@ -11,7 +11,7 @@ import org.bdwallet.app.ui.wallet.WalletActivity
 import org.bitcoindevkit.bdkjni.Types.*
 
 class CreateWalletSeedActivity : AppCompatActivity() {
-    private lateinit var keys: ExtendedKeys
+    private lateinit var keys: ExtendedKey
 
     override fun onStart() {
         super.onStart()
@@ -27,7 +27,7 @@ class CreateWalletSeedActivity : AppCompatActivity() {
     // Generate mnemonic words and fill them into the respective TextViews
     private fun fillSeedWords() {
         val app = application as BDWApplication
-        this.keys = app.generateExtendedKey(12)
+        this.keys = app.generateExtendedKey(12, null)
         val words: List<String> = keys.mnemonic.split(' ')
         val seedViews: List<Int> = listOfNotNull<Int>(R.id.seed_text_1, R.id.seed_text_2, R.id.seed_text_3, R.id.seed_text_4,
             R.id.seed_text_5, R.id.seed_text_6, R.id.seed_text_7, R.id.seed_text_8, R.id.seed_text_9, R.id.seed_text_10,

--- a/app/src/main/java/org/bdwallet/app/ui/init/CreateWalletSeedActivity.kt
+++ b/app/src/main/java/org/bdwallet/app/ui/init/CreateWalletSeedActivity.kt
@@ -11,7 +11,7 @@ import org.bdwallet.app.ui.wallet.WalletActivity
 import org.bitcoindevkit.bdkjni.Types.*
 
 class CreateWalletSeedActivity : AppCompatActivity() {
-    private lateinit var keys: ExtendedKey
+    private lateinit var key: ExtendedKey
 
     override fun onStart() {
         super.onStart()
@@ -27,8 +27,8 @@ class CreateWalletSeedActivity : AppCompatActivity() {
     // Generate mnemonic words and fill them into the respective TextViews
     private fun fillSeedWords() {
         val app = application as BDWApplication
-        this.keys = app.generateExtendedKey(12, null)
-        val words: List<String> = keys.mnemonic.split(' ')
+        this.key = app.generateExtendedKey(12, null)
+        val words: List<String> = key.mnemonic.split(' ')
         val seedViews: List<Int> = listOfNotNull<Int>(R.id.seed_text_1, R.id.seed_text_2, R.id.seed_text_3, R.id.seed_text_4,
             R.id.seed_text_5, R.id.seed_text_6, R.id.seed_text_7, R.id.seed_text_8, R.id.seed_text_9, R.id.seed_text_10,
             R.id.seed_text_11, R.id.seed_text_12)
@@ -62,15 +62,15 @@ class CreateWalletSeedActivity : AppCompatActivity() {
             .setNegativeButton(R.string.back_btn) { _, _ -> }
             .setPositiveButton(R.string.reminder_dialog_btn) { _, _ ->
                 // Once the user confirms, create the wallet using the previously generated keys
-                val descriptor: String = app.createDescriptor(keys)
-                val changeDescriptor: String = app.createChangeDescriptor(keys)
+                val descriptor: String = app.createDescriptor(key)
+                val changeDescriptor: String = app.createChangeDescriptor(key)
                 app.createWallet(descriptor, changeDescriptor)
                 finish()
                 startActivity(Intent(this, WalletActivity::class.java))
             }
             .create()
         alertDialog.setOnShowListener {
-            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(resources.getColor(android.R.color.darker_gray))
+            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(resources.getColor(android.R.color.darker_gray, null))
         }
         alertDialog.show()
     }

--- a/app/src/main/java/org/bdwallet/app/ui/init/RecoverWalletActivity.kt
+++ b/app/src/main/java/org/bdwallet/app/ui/init/RecoverWalletActivity.kt
@@ -12,15 +12,12 @@ import androidx.appcompat.app.AppCompatActivity
 import org.bdwallet.app.BDWApplication
 import org.bdwallet.app.R
 import org.bdwallet.app.ui.wallet.WalletActivity
-import org.bitcoindevkit.bdkjni.Types.ExtendedKeys
-
-
-import java.lang.reflect.InvocationTargetException
+import org.bitcoindevkit.bdkjni.Types.ExtendedKey
 
 
 class RecoverWalletActivity : AppCompatActivity() {
     private lateinit var viewList : List<Int>
-    private lateinit var keys: ExtendedKeys
+    private lateinit var key: ExtendedKey
     private lateinit var wordList : List<String>
 
     override fun onSupportNavigateUp(): Boolean {
@@ -91,7 +88,7 @@ class RecoverWalletActivity : AppCompatActivity() {
         val mnemonicString: String = mnemonicWordList.joinToString(separator = " ")
         val app = application as BDWApplication
         try {
-            this.keys = app.createExtendedKeys(mnemonicString)
+            this.key = app.restoreExtendedKey(mnemonicString, null)
         } catch (e: Throwable) {
             Log.d("createExtendedKeys EXCEPTION:", "MSG: ".plus(e.message).plus(" | mnemonic: ").plus(mnemonicString))
             return false
@@ -102,8 +99,8 @@ class RecoverWalletActivity : AppCompatActivity() {
     // Call BDK library to load the wallet using the recovered private key
     private fun loadWallet() {
         val app = application as BDWApplication
-        val descriptor: String = app.createDescriptor(this.keys)
-        val changeDescriptor: String = app.createChangeDescriptor(this.keys)
+        val descriptor: String = app.createDescriptor(this.key)
+        val changeDescriptor: String = app.createChangeDescriptor(this.key)
         app.createWallet(descriptor, changeDescriptor)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ allprojects {
         mavenLocal()
         google()
         jcenter()
+        flatDir {
+            dirs 'libs'
+        }
     }
 }
 


### PR DESCRIPTION
This PR also contains some README.md updates with instructions for using a local `app/libs` version of the bdk-jni library.